### PR TITLE
feat: add minimal OS preparation tool

### DIFF
--- a/docs/minimal-os-tool.md
+++ b/docs/minimal-os-tool.md
@@ -1,0 +1,67 @@
+# Minimal OS Preparation Tool
+
+This tool automates transforming a Linux system into a minimal, clean, hardened base image suitable for production.
+
+## Architecture / Flow
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Pre-flight checks]
+    B --> C[Backup]
+    C --> D[Analysis]
+    D --> E[Cleanup]
+    E --> F[Update]
+    F --> G[Install essentials]
+    G --> H[Hardening]
+    H --> I[Final checks]
+    I --> J[Reboot]
+```
+
+## Default package actions
+
+- **Removed**: `snapd`, `apport`, `whoopsie`, `popularity-contest`, `ubuntu-release-upgrader-core`, `landscape-client`, `cloud-init`, `lxd`, `lxd-client`
+- **Essential installs**: `openssh-server`, `sudo`, `curl`, `wget`, `vim`, `git`, `net-tools`, `ca-certificates`
+
+## Running the tool
+
+```bash
+sudo ./minimal-os-tool.sh            # headless
+sudo ./minimal-os-tool.sh -i         # interactive
+sudo ./minimal-os-tool.sh -n         # dry-run
+```
+
+Logs are written to `/var/log/minimal-os-tool.log`. A backup of `/etc` and the installed package list is placed in `/var/backups/minimal-tool/`.
+
+## Sample output (dry-run)
+
+```
+$ sudo ./minimal-os-tool.sh -n
+[2025-02-14 12:00:00] --- Pre-flight checks ---
+[2025-02-14 12:00:00] Package manager: apt
+[2025-02-14 12:00:00] --- Backup phase ---
+[DRY-RUN] mkdir -p /var/backups/minimal-tool
+...
+[2025-02-14 12:00:00] Completed. Reboot recommended.
+```
+
+## Testing in a VM
+
+1. Create a fresh VM (Ubuntu Server or Rocky Linux).
+2. Snapshot the VM before running the script.
+3. Copy `minimal-os-tool.sh` to the VM.
+4. Run a dry run first: `sudo ./minimal-os-tool.sh -n`.
+5. If results look safe, run: `sudo ./minimal-os-tool.sh`.
+6. Reboot and verify:
+   - SSH connectivity
+   - `systemctl --failed` shows no failures
+   - `systemd-analyze` reports improved boot time
+
+## Boot time optimisation tips
+
+- Use `systemd-analyze blame` to identify slow services.
+- Mask unneeded services with `systemctl mask <service>`.
+- Disable graphical targets if not required: `systemctl set-default multi-user.target`.
+
+## Common pitfalls
+
+Removing critical packages such as network tools or SSH may lock you out. Always review the package lists and run in a disposable environment first.

--- a/minimal-os-tool.sh
+++ b/minimal-os-tool.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Minimal OS preparation tool
+# Transforms a Linux system into a minimal, clean, hardened base image
+
+set -euo pipefail
+
+LOG_FILE="/var/log/minimal-os-tool.log"
+DRY_RUN=0
+INTERACTIVE=0
+BACKUP=1
+
+# Default package lists
+REMOVE_PKGS=(
+    snapd
+    apport
+    whoopsie
+    popularity-contest
+    ubuntu-release-upgrader-core
+    landscape-client
+    cloud-init
+    lxd
+    lxd-client
+)
+ESSENTIAL_PKGS=(
+    openssh-server
+    sudo
+    curl
+    wget
+    vim
+    git
+    net-tools
+    ca-certificates
+)
+
+# Hardening settings
+SYSCTL_CONF=$(cat <<'HARDEN'
+# Harden network stack
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+HARDEN
+)
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+run_cmd() {
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log "[DRY-RUN] $*"
+    else
+        log "Running: $*"
+        eval "$@"
+    fi
+}
+
+usage() {
+    cat <<USAGE
+Usage: $0 [options]
+
+Options:
+  -n            Dry-run mode
+  -i            Interactive mode
+  -b            Disable backups
+  -h            Show this help
+USAGE
+}
+
+parse_args() {
+    while getopts "nibh" opt; do
+        case $opt in
+            n) DRY_RUN=1 ;;
+            i) INTERACTIVE=1 ;;
+            b) BACKUP=0 ;;
+            h) usage; exit 0 ;;
+            *) usage; exit 1 ;;
+        esac
+    done
+}
+
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "This script must be run as root" >&2
+        exit 1
+    fi
+}
+
+preflight_checks() {
+    log "--- Pre-flight checks ---"
+    if ! ping -c1 -W1 8.8.8.8 >/dev/null 2>&1; then
+        log "No internet connectivity" && exit 1
+    fi
+    if [[ $(df / | tail -1 | awk '{print $4}') -lt 1048576 ]]; then
+        log "Less than 1GB free on /" && exit 1
+    fi
+    if command -v apt-get >/dev/null; then
+        PKG_MGR="apt"
+    elif command -v dnf >/dev/null; then
+        PKG_MGR="dnf"
+    elif command -v yum >/dev/null; then
+        PKG_MGR="yum"
+    else
+        log "Unsupported package manager" && exit 1
+    fi
+    log "Package manager: $PKG_MGR"
+}
+
+backup_system() {
+    [[ $BACKUP -eq 0 ]] && return
+    log "--- Backup phase ---"
+    run_cmd "mkdir -p /var/backups/minimal-tool"
+    run_cmd "tar czf /var/backups/minimal-tool/etc-$(date +%F).tgz /etc"
+    case $PKG_MGR in
+        apt)
+            run_cmd "dpkg --get-selections > /var/backups/minimal-tool/pkglist-$(date +%F).txt" ;;
+        dnf|yum)
+            run_cmd "rpm -qa > /var/backups/minimal-tool/pkglist-$(date +%F).txt" ;;
+    esac
+}
+
+analysis_phase() {
+    log "--- Analysis phase ---"
+    run_cmd "df -h"
+    run_cmd "systemctl list-unit-files --state=enabled"
+}
+
+is_installed() {
+    case $PKG_MGR in
+        apt) dpkg -l "$1" >/dev/null 2>&1 ;;
+        dnf|yum) rpm -q "$1" >/dev/null 2>&1 ;;
+    esac
+}
+
+cleanup_phase() {
+    log "--- Cleanup phase ---"
+    for pkg in "${REMOVE_PKGS[@]}"; do
+        if is_installed "$pkg"; then
+            run_cmd "$PKG_MGR -y remove $pkg"
+        else
+            log "$pkg not installed"
+        fi
+    done
+    case $PKG_MGR in
+        apt) run_cmd "$PKG_MGR autoremove -y && $PKG_MGR clean" ;;
+        dnf|yum) run_cmd "$PKG_MGR autoremove -y" ;;
+    esac
+}
+
+update_phase() {
+    log "--- Update phase ---"
+    case $PKG_MGR in
+        apt) run_cmd "$PKG_MGR update && $PKG_MGR -y dist-upgrade" ;;
+        dnf|yum) run_cmd "$PKG_MGR -y update" ;;
+    esac
+}
+
+install_essentials() {
+    log "--- Install essentials ---"
+    for pkg in "${ESSENTIAL_PKGS[@]}"; do
+        if is_installed "$pkg"; then
+            log "$pkg already installed"
+        else
+            run_cmd "$PKG_MGR -y install $pkg"
+        fi
+    done
+}
+
+hardening_phase() {
+    log "--- Hardening phase ---"
+    run_cmd "printf '%s\n' '$SYSCTL_CONF' > /etc/sysctl.d/99-hardening.conf"
+    run_cmd "sysctl --system"
+    run_cmd "sed -ri 's/^#?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config"
+    run_cmd "systemctl restart sshd 2>/dev/null || systemctl restart ssh"
+}
+
+final_checks() {
+    log "--- Final checks ---"
+    run_cmd "$PKG_MGR check"
+    run_cmd "systemctl --failed || true"
+    run_cmd "systemd-analyze blame || true"
+    log "Completed. Reboot recommended."
+}
+
+confirm() {
+    [[ $INTERACTIVE -eq 0 ]] && return
+    read -rp "$1 [y/N]: " ans
+    [[ ${ans:-N} =~ ^[Yy]$ ]]
+}
+
+main() {
+    parse_args "$@"
+    require_root
+    preflight_checks
+    confirm "Proceed with backup?" && backup_system
+    confirm "Run analysis?" && analysis_phase
+    confirm "Run cleanup?" && cleanup_phase
+    confirm "Apply updates?" && update_phase
+    confirm "Install essentials?" && install_essentials
+    confirm "Apply hardening?" && hardening_phase
+    final_checks
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add script to strip and harden a Linux host into a minimal base image
- document flow, default package sets, usage and testing instructions

## Testing
- `bash -n minimal-os-tool.sh`
- `shellcheck minimal-os-tool.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `./minimal-os-tool.sh -n` *(fails: No internet connectivity)*

------
https://chatgpt.com/codex/tasks/task_e_689249aeade883338703f7712a163df3